### PR TITLE
Fix typo in notebook

### DIFF
--- a/03_models_avancado.ipynb
+++ b/03_models_avancado.ipynb
@@ -404,7 +404,7 @@
    "id": "751f63b9",
    "metadata": {},
    "source": [
-    "Rodandando a primeira vez"
+    "Rodando a primeira vez"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- fix a typo in the `03_models_avancado` notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b920b6d8832fb89f01935036b820